### PR TITLE
chore(deps): Remove packaging dependency

### DIFF
--- a/bin/ktool
+++ b/bin/ktool
@@ -26,6 +26,7 @@ from enum import Enum
 from typing import Union
 
 from kimg4.img4 import IM4P
+from pkg_resources import packaging
 from kmacho import LOAD_COMMAND
 
 from ktool import (
@@ -61,13 +62,19 @@ def get_terminal_size():
         return os.terminal_size((5000, 5000))
 
 
+def handle_version(version: str):
+    """ Used by check_for_update """
+    return packaging.version.parse(version)
+
+
 def check_for_update():
     endpoint = "https://pypi.org/pypi/k2l/json"
     # noinspection PyBroadException
     try:
         with urllib.request.urlopen(endpoint, timeout=1) as url:
             data = json.loads(url.read().decode(), strict=False)
-        if KTOOL_VERSION < data.get('info').get('version'):
+        new_version = data.get('info').get('version')
+        if handle_version(KTOOL_VERSION) < handle_version(new_version):
             global UPDATE_AVAILABLE
             UPDATE_AVAILABLE = True
     except Exception:

--- a/bin/ktool
+++ b/bin/ktool
@@ -26,8 +26,6 @@ from enum import Enum
 from typing import Union
 
 from kimg4.img4 import IM4P
-from packaging.version import Version
-
 from kmacho import LOAD_COMMAND
 
 from ktool import (
@@ -69,7 +67,7 @@ def check_for_update():
     try:
         with urllib.request.urlopen(endpoint, timeout=1) as url:
             data = json.loads(url.read().decode(), strict=False)
-        if Version(KTOOL_VERSION) < Version(data['info']['version']):
+        if KTOOL_VERSION < data.get('info').get('version'):
             global UPDATE_AVAILABLE
             UPDATE_AVAILABLE = True
     except Exception:

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
-
 from pathlib import Path
+
 this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text()
 
@@ -12,7 +12,7 @@ setup(name='k2l',
       python_requires='>=3.6',
       author='kritanta',
       url='https://github.com/cxnder/ktool',
-      install_requires=['pyaes', 'kimg4', 'Pygments', 'packaging'],
+      install_requires=['pyaes', 'kimg4', 'Pygments'],
       packages=['kmacho', 'ktool', 'kswift'],
       package_dir={
             'kmacho': 'src/kmacho',


### PR DESCRIPTION
This PR removes the redundant ``packaging`` dependency that ktool (currently) has. It's evident that such package is not needed; see the example below.

```python
(venv) ~/Projects/ktool keto% python
Python 3.9.9 (main, Jan 21 2022, 10:41:38)
[Clang 13.0.0 (clang-1300.0.29.3)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import json
>>> import urllib.request
>>>
>>> ktool_ver_test = "0.20.0"
>>> endpoint = "https://pypi.org/pypi/k2l/json"
>>>
>>> with urllib.request.urlopen(endpoint, timeout=1) as url:
...     data = json.loads(url.read().decode(), strict=False)
...
>>> ktool_new_ver = data.get("info").get("version")
>>> if ktool_ver_test < ktool_new_ver:
...     print("A new version is available!")
...     print("Wow, imagine using an entire library for this")
...
A new version is available!
Wow, imagine using an entire library for this
>>> print(ktool_ver_test)
0.20.0
>>> print(ktool_new_ver)
0.20.1
>>>
```