### PR TITLE
chore(legacy): Adapt to package changes

### DIFF
--- a/.legacy_setup.py
+++ b/.legacy_setup.py
@@ -4,25 +4,37 @@ from pathlib import Path
 this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text()
 
-setup(name='k2l',
-      version='1.0.0rc0',
-      description='Static MachO/ObjC Reverse Engineering Toolkit',
-      long_description=long_description,
-      long_description_content_type='text/markdown',
-      python_requires='>=3.6',
-      author='kritanta',
-      url='https://github.com/cxnder/ktool',
-      install_requires=['pyaes', 'kimg4', 'Pygments'],
-      packages=['kmacho', 'ktool', 'kswift'],
-      package_dir={
-            'kmacho': 'src/kmacho',
-            'ktool': 'src/ktool',
-            'kswift': 'src/kswift'
-      },
-      classifiers=[
-            'Programming Language :: Python :: 3',
-            'License :: OSI Approved :: MIT License',
-            'Operating System :: OS Independent'
-      ],
-      scripts=['bin/ktool']
-      )
+setup(
+    name = 'k2l',
+    version = "1.0.0",
+    description = 'Static MacO/ObjC Reverse Engineering Toolkit',
+    long_description = long_description,
+    long_description_content_type = 'text/markdown',
+    python_requires = '>=3.6',
+    author = 'cynder',
+    license = 'MIT',
+    url = 'https://github.com/cxnder/ktool',
+    install_requires = [
+        'pyaes',
+        'kimg4',
+        'Pygments'
+    ],
+    packages = ['kmacho', 'ktool', 'kswift'],
+    package_dir = {
+        'kmacho': 'src/kmacho',
+        'ktool': 'src/ktool',
+        'kswift': 'src/kswift'
+    },
+    classifiers = [
+        'Programming Language :: Python :: 3',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: OS Independent'
+    ],
+    entry_points = {'console_scripts': [
+        'ktool=ktool.ktool_script:main'
+    ]},
+    project_urls = {
+        'Documentation': 'https://ktool.cynder.me/en/latest/ktool.html',
+        'Issue Tracker': 'https://github.com/cxnder/ktool/issues'
+    }
+)

--- a/.legacy_setup.py
+++ b/.legacy_setup.py
@@ -6,7 +6,6 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name = 'k2l',
-    version = "1.0.0",
     description = 'Static MacO/ObjC Reverse Engineering Toolkit',
     long_description = long_description,
     long_description_content_type = 'text/markdown',


### PR DESCRIPTION
This PR updates ``.legacy_setup.py`` in order to work with the new changes made to the library. Specific changes were documented under the commit message.

When updating versions, make sure to update the one set in ``pyproject.toml`` as well as the one set in the legacy setup script, and everything else should be fine; Procursus doesn't use poetry unfortunately, so this is a required patch in order for that to continue building. 