### PR TITLE
Large Amount of changes

### DIFF
--- a/src/kmacho/load_commands.py
+++ b/src/kmacho/load_commands.py
@@ -78,7 +78,7 @@ class SegmentLoadCommand(LoadCommand):
         return lc
 
     @classmethod
-    def from_values(cls, is_64, name, vm_addr, file_addr, size, maxprot, initprot, flags, sections):
+    def from_values(cls, is_64, name, vm_addr, vm_size, file_addr, file_size, maxprot, initprot, flags, sections):
         lc = SegmentLoadCommand()
 
         assert len(name) <= 16
@@ -90,7 +90,7 @@ class SegmentLoadCommand(LoadCommand):
         cmdsize = command_type.SIZE
         cmdsize += (len(sections) * section_type.SIZE)
 
-        command = Struct.create_with_values(command_type, [cmd, cmdsize, name, vm_addr, size, file_addr, size, maxprot, initprot, len(sections), flags])
+        command = Struct.create_with_values(command_type, [cmd, cmdsize, name, vm_addr, vm_size, file_addr, file_size, maxprot, initprot, len(sections), flags])
 
         lc.cmd = command
 

--- a/src/kmacho/load_commands.py
+++ b/src/kmacho/load_commands.py
@@ -86,7 +86,7 @@ class SegmentLoadCommand(LoadCommand):
         command_type = segment_command_64 if is_64 else segment_command
         section_type = section_64 if is_64 else section
         cmd = 0x19 if is_64 else 0x1
-        # 'cmd', 'cmdsize', 'segname', 'vmaddr', 'vmsize', 'fileoff', 'filesize', 'maxprot', 'initprot', 'nsects', 'flags'
+
         cmdsize = command_type.SIZE
         cmdsize += (len(sections) * section_type.SIZE)
 
@@ -128,4 +128,4 @@ class SegmentLoadCommand(LoadCommand):
 
         self.sections = {}
 
-
+# TODO: Constructable wrapper for dylinker_command, build_version_command

--- a/src/kmacho/structs.py
+++ b/src/kmacho/structs.py
@@ -160,6 +160,18 @@ class Struct:
             return self._rebuild_raw()
         return super().__getattribute__(item)
 
+    def __eq__(self, other):
+        try:
+            for field in self._fields:
+                if self.__getattribute__(field) != getattr(other, field):
+                    return False
+        except AttributeError:
+            return False
+        return True
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     def __str__(self):
         text = f'{self.__class__.__name__}('
         for field in self._fields:

--- a/src/ktool/__init__.py
+++ b/src/ktool/__init__.py
@@ -1,7 +1,7 @@
 from ktool.ktool import load_image, load_objc_metadata, generate_headers, generate_text_based_stub, load_macho_file, macho_verify, reload_image, macho_combine
 
 from ktool.objc import ObjCImage
-from ktool.dyld import Dyld, LD64, Image
+from ktool.loader import MachOImageLoader, Image
 from ktool.macho import Slice, MachOFile, MachOFileType, Segment, Section
 try:
     from ktool.headers import HeaderGenerator, Header

--- a/src/ktool/generator.py
+++ b/src/ktool/generator.py
@@ -17,7 +17,7 @@ from collections import namedtuple
 
 from kmacho.structs import *
 from ktool.util import log
-from ktool.dyld import Dyld, SymbolType, Image
+from ktool.loader import MachOImageLoader, SymbolType, Image
 from ktool.macho import Slice
 from ktool.objc import ObjCImage
 
@@ -130,7 +130,7 @@ class FatMachOGenerator:
         :return: fat_arch_for_slice item.
         :rtype: fat_arch_for_slice
         """
-        lib = Dyld.load(fat_slice)
+        lib = MachOImageLoader.load(fat_slice)
         cpu_type = lib.macho_header.dyld_header.cpu_type
         cpu_subtype = lib.macho_header.dyld_header.cpu_subtype
 

--- a/src/ktool/headers.py
+++ b/src/ktool/headers.py
@@ -14,14 +14,17 @@
 
 from typing import List, Dict
 
-from ktool.dyld import SymbolType, Image
+from ktool.loader import SymbolType, Image
 from ktool.objc import ObjCImage, Class, Category, Protocol, Property, Method, Ivar
 
 from ktool.util import KTOOL_VERSION
 
 from pygments import highlight
 from pygments.formatters.terminal import TerminalFormatter
-from pygments.lexers.objective import ObjectiveCLexer
+try:
+    from pygments.lexers.objective import ObjectiveCLexer
+except ImportError:
+    ObjectiveCLexer = None
 
 
 class HeaderUtils:
@@ -180,6 +183,8 @@ class Header:
         return self.text
 
     def generate_highlighted_text(self):
+        if ObjectiveCLexer is None:
+            return self.text
         if self.highlighted_text:
             return self.highlighted_text
 

--- a/src/ktool/headers.py
+++ b/src/ktool/headers.py
@@ -463,14 +463,8 @@ class Interface:
         for objc_property in self.objc_class.properties:
             if not hasattr(objc_property, 'type'):
                 continue
-            if objc_property.type.lower() == 'bool':
-                getter_name = 'is' + objc_property.name[0].upper() + objc_property.name[1:]
-                self.getters.append(getter_name)
-            else:
-                self.getters.append(objc_property.name)
-            if 'readonly' not in objc_property.attributes:
-                setter_name = 'set' + objc_property.name[0].upper() + objc_property.name[1:]
-                self.setters.append(setter_name)
+            self.getters.append(objc_property.getter)
+            self.setters.append(objc_property.setter)
             self.properties.append(objc_property)
 
     def _process_ivars(self):

--- a/src/ktool/image.py
+++ b/src/ktool/image.py
@@ -1,0 +1,430 @@
+from collections import namedtuple
+from enum import Enum
+from typing import List, Dict, Union
+
+from kmacho import LOAD_COMMAND, dylib_command, dyld_info_command, Struct, CPUSubTypeARM64, CPUType, segment_command_64
+from kmacho.base import Constructable
+from ktool.codesign import CodesignInfo
+from ktool.exceptions import VMAddressingError, MachOAlignmentError
+from ktool.util import bytes_to_hex, log
+from ktool.macho import Slice, SlicedBackingFile, MachOImageHeader, Segment, PlatformType, ToolType
+
+
+os_version = namedtuple("os_version", ["x", "y", "z"])
+
+
+class VM:
+    """
+    New Virtual Address translation based on actual VM -> physical pages
+
+    """
+
+    def __init__(self, page_size):
+        self.page_size = page_size
+        self.page_size_bits = (self.page_size - 1).bit_length()
+        self.page_table = {}
+        self.tlb = {}
+        self.vm_base_addr = None
+        self.dirty = False
+
+        self.fallback: Union[None, MisalignedVM] = None
+
+        self.detag_kern_64 = False
+        self.detag_64 = False
+
+    def vm_check(self, address):
+        try:
+            self.translate(address)
+            return True
+        except ValueError:
+            return False
+
+    def add_segment(self, segment: Segment):
+        if segment.name == '__PAGEZERO':
+            return
+
+        self.fallback.add_segment(segment)
+
+        if self.vm_base_addr is None:
+            self.vm_base_addr = segment.vm_address
+
+        self.map_pages(segment.file_address, segment.vm_address, segment.size)
+
+    def translate(self, address) -> int:
+
+        l_addr = address
+
+        if self.detag_kern_64:
+            address = address | (0xFFFF << 12*4)
+
+        if self.detag_64:
+            address = address & 0xFFFFFFFFF
+
+        try:
+            return self.tlb[address]
+        except KeyError:
+            pass
+
+        page_offset = address & self.page_size - 1
+        page_location = address >> self.page_size_bits
+        try:
+            phys_page = self.page_table[page_location]
+            physical_location = phys_page + page_offset
+            self.tlb[address] = physical_location
+            return physical_location
+        except KeyError:
+
+            log.info(f'Address {hex(address)} not mapped, attempting fallback')
+
+            try:
+                return self.fallback.translate(address)
+            except VMAddressingError:
+                raise VMAddressingError(f'Address {hex(address)} ({hex(l_addr)}) not in VA Table or fallback map. (page: {hex(page_location)})')
+
+    def map_pages(self, physical_addr, virtual_addr, size):
+        if physical_addr % self.page_size != 0 or virtual_addr % self.page_size != 0 or size % self.page_size != 0:
+            raise MachOAlignmentError
+        for i in range(size // self.page_size):
+            self.page_table[virtual_addr + (i * self.page_size) >> self.page_size_bits] = physical_addr + (
+                        i * self.page_size)
+
+
+vm_obj = namedtuple("vm_obj", ["vmaddr", "vmend", "size", "fileaddr", "name"])
+
+
+class MisalignedVM:
+    """
+    This is the manual backup if the image cant be mapped to 16/4k segments
+    """
+
+    def __init__(self, macho_slice):
+        self.slice = macho_slice
+
+        self.detag_kern_64 = False
+        self.detag_64 = False
+
+        self.map = {}
+        self.stats = {}
+        self.vm_base_addr = 0
+        self.sorted_map = {}
+        self.cache = {}
+
+    def vm_check(self, vm_address):
+        try:
+            self.translate(vm_address)
+            return True
+        except ValueError:
+            return False
+
+    def translate(self, vm_address: int) -> int:
+
+        if self.detag_kern_64:
+            vm_address = vm_address | (0xFFFF << 12*4)
+
+        if self.detag_64:
+            vm_address = vm_address & 0xFFFFFFFFF
+
+        if vm_address in self.cache:
+            return self.cache[vm_address]
+
+        for o in self.map.values():
+            # noinspection PyChainedComparisons
+            if vm_address >= o.vmaddr and o.vmend >= vm_address:
+                file_addr = o.fileaddr + vm_address - o.vmaddr
+                self.cache[vm_address] = file_addr
+                return file_addr
+
+        raise VMAddressingError(f'Address {hex(vm_address)} couldn\'t be found in vm address set')
+
+    def add_segment(self, segment: Segment):
+        if segment.file_address == 0 and segment.size != 0:
+            self.vm_base_addr = segment.vm_address
+
+        if len(segment.sections) == 0:
+            seg_obj = vm_obj(segment.vm_address, segment.vm_address + segment.size, segment.size, segment.file_address,
+                             segment.name)
+            log.info(str(seg_obj))
+            self.map[segment.name] = seg_obj
+            self.stats[segment.name] = 0
+        else:
+            for section in segment.sections.values():
+                name = section.name if section.name not in self.map.keys() else section.name + '2'
+                sect_obj = vm_obj(section.vm_address, section.vm_address + section.size, section.size,
+                                  section.file_address, name)
+                log.info(str(sect_obj))
+                self.map[name] = sect_obj
+                self.sorted_map = {k: v for k, v in sorted(self.map.items(), key=lambda item: item[1].vmaddr)}
+                self.stats[name] = 0
+
+
+class LinkedImage:
+    def __init__(self, source_image: 'Image', cmd):
+        self.cmd = cmd
+        self.source_image = source_image
+
+        self.install_name = self._get_name(cmd)
+        self.weak = cmd.cmd == LOAD_COMMAND.LOAD_WEAK_DYLIB.value
+        self.local = cmd.cmd == LOAD_COMMAND.ID_DYLIB.value
+
+    def serialize(self):
+        return {
+            'install_name': self.install_name,
+            'load_command': LOAD_COMMAND(self.cmd.cmd).name
+        }
+
+    def _get_name(self, cmd) -> str:
+        read_address = cmd.off + dylib_command.SIZE
+        return self.source_image.get_cstr_at(read_address)
+
+
+class Image:
+    """
+    This class represents the Mach-O Binary as a whole.
+
+    It's the root object in the massive tree of information we're going to build up about the binary
+
+    This class on its own does not handle populating its fields.
+    The Dyld class set is responsible for loading in and processing the raw values to it.
+    """
+
+    def __init__(self, macho_slice: Slice):
+        """
+        Create a MachO image
+
+        :param macho_slice: MachO Slice being processed
+        :type macho_slice: MachO Slice
+        """
+        self.slice: Slice = macho_slice
+
+        self.vm = None
+
+        self.fallback_vm = MisalignedVM(self.slice)
+
+        if self.slice:
+            self.macho_header: MachOImageHeader = MachOImageHeader.from_image(macho_slice=macho_slice)
+
+            self.vm_realign()
+
+        self.base_name = ""  # copy of self.name
+        self.install_name = ""
+
+        self.linked_images: List[LinkedImage] = []
+
+        self.segments: Dict[str, Segment] = {}
+
+        self.info: Union[dyld_info_command, None] = None
+        self.dylib: Union[LinkedImage, None] = None
+        self.uuid = None
+        self.codesign_info: Union[CodesignInfo, None] = None
+
+        self._codesign_cmd = None
+
+        self.platform: PlatformType = PlatformType.UNK
+
+        self.allowed_clients: List[str] = []
+
+        self.rpath: Union[str, None] = None
+
+        self.minos = os_version(0, 0, 0)
+        self.sdk_version = os_version(0, 0, 0)
+
+        self.imports: List['Symbol'] = []
+        self.exports: List['Symbol'] = []
+
+        self.symbols: Dict[int, 'Symbol'] = {}
+        self.import_table: Dict[int, 'Symbol'] = {}
+        self.export_table: Dict[int, 'Symbol'] = {}
+
+        self.entry_point = 0
+
+        self.function_starts: List[int] = []
+
+        self.thread_state: List[int] = []
+        self._entry_off = 0
+
+        self.binding_table = None
+        self.weak_binding_table = None
+        self.lazy_binding_table = None
+        self.export_trie = None
+
+        self.chained_fixups = None
+
+        self.symbol_table = None
+
+        self.struct_cache: Dict[int, Struct] = {}
+
+    def serialize(self):
+        image_dict = {
+            'macho_header': self.macho_header.serialize()
+        }
+
+        if self.install_name != "":
+            image_dict['install_name'] = self.install_name
+
+        linked = []
+        for ext_dylib in self.linked_images:
+            linked.append(ext_dylib.serialize())
+
+        image_dict['linked'] = linked
+
+        segments = {}
+
+        for seg_name, seg in self.segments.items():
+            segments[seg_name] = seg.serialize()
+
+        image_dict['segments'] = segments
+        if self.uuid:
+            image_dict['uuid'] = bytes_to_hex(self.uuid)
+
+        image_dict['platform'] = self.platform.name
+
+        image_dict['allowed-clients'] = self.allowed_clients
+
+        if self.rpath:
+            image_dict['rpath'] = self.rpath
+
+        image_dict['imports'] = [sym.serialize() for sym in self.imports]
+        image_dict['exports'] = [sym.serialize() for sym in self.exports]
+        image_dict['symbols'] = [sym.serialize() for sym in self.symbols.values()]
+
+        image_dict['entry_point'] = self.entry_point
+
+        image_dict['function_starts'] = self.function_starts
+
+        image_dict['thread_state'] = self.thread_state
+
+        image_dict['minos'] = f'{self.minos.x}.{self.minos.y}{self.minos.z}'
+        image_dict['sdk_version'] = f'{self.sdk_version.x}.{self.sdk_version.y}.{self.sdk_version.z}'
+
+        return image_dict
+
+    def vm_realign(self, yell_about_misalignment=True):
+
+        align_by = 0x4000
+        aligned = False
+
+        detag_64 = False
+
+        segs = []
+        for cmd in self.macho_header.load_commands:
+            if cmd.cmd in [LOAD_COMMAND.SEGMENT.value, LOAD_COMMAND.SEGMENT_64.value]:
+                segs.append(cmd)
+            if cmd.cmd == LOAD_COMMAND.LC_DYLD_CHAINED_FIXUPS:
+                detag_64 = True
+
+        if self.slice.type == CPUType.ARM64 and self.slice.subtype == CPUSubTypeARM64.ARM64E:
+            detag_64 = True
+
+        while not aligned:
+            aligned = True
+            for cmd in segs:
+                cmd: segment_command_64 = cmd
+                if cmd.vmaddr % align_by != 0:
+                    if align_by == 0x4000:
+                        align_by = 0x1000
+                        aligned = False
+                        break
+                    else:
+                        align_by = 0
+                        aligned = True
+                        break
+
+        if align_by != 0:
+            log.info(f'Aligned to {hex(align_by)} pages')
+            self.vm: VM = VM(page_size=align_by)
+            self.vm.detag_64 = detag_64
+            self.vm.fallback = self.fallback_vm
+        else:
+            if yell_about_misalignment:
+                log.info("MachO cannot be aligned to 16k or 4k pages. Swapping to fallback mapping.")
+            self.vm: MisalignedVM = self.fallback_vm
+            self.vm.detag_64 = detag_64
+
+    def vm_check(self, address):
+        return self.vm.vm_check(address)
+
+    def get_int_at(self, offset: int, length: int, vm=False, section_name=None):
+        """
+        Get a sequence of bytes (as an int) from a location
+
+        :param offset: Offset within the image
+        :param length: Amount of bytes to get
+        :param vm: Is `offset` a VM address
+        :param section_name: Section Name if vm==True (improves translation time slightly)
+        :return: `length` Bytes at `offset`
+        """
+        if vm:
+            offset = self.vm.translate(offset)
+        return self.slice.get_int_at(offset, length)
+
+    def get_bytes_at(self, offset: int, length: int, vm=False, section_name=None):
+        """
+        Get a sequence of bytes from a location
+
+        :param offset: Offset within the image
+        :param length: Amount of bytes to get
+        :param vm: Is `offset` a VM address
+        :param section_name: Section Name if vm==True (improves translation time slightly)
+        :return: `length` Bytes at `offset`
+        """
+        if vm:
+            offset = self.vm.translate(offset)
+        return self.slice.get_bytes_at(offset, length)
+
+    def load_struct(self, address: int, struct_type, vm=False, section_name=None, endian="little", force_reload=False):
+        """
+        Load a struct (struct_type_t) from a location and return the processed object
+
+        :param address: Address to load struct from
+        :param struct_type: type of struct (e.g. dyld_header)
+        :param vm:  Is `address` a VM address?
+        :param section_name: if `vm==True`, the section name (slightly improves translation speed)
+        :param endian: Endianness of bytes to read.
+        :return: Loaded struct
+        """
+        if address not in self.struct_cache or force_reload:
+            if vm:
+                address = self.vm.translate(address)
+            struct = self.slice.load_struct(address, struct_type, endian)
+            self.struct_cache[address] = struct
+            return struct
+
+        return self.struct_cache[address]
+
+    def get_str_at(self, address: int, count: int, vm=False, section_name=None, force=False):
+        """
+        Get string with set length from location (to be used essentially only for loading segment names)
+
+        :param address: Address of string start
+        :param count: Length of string
+        :param vm: Is `address` a VM address?
+        :param section_name: if `vm==True`, the section name (unused here, really)
+        :return: The loaded string.
+        """
+        if vm:
+            address = self.vm.translate(address)
+        return self.slice.get_str_at(address, count, force=force)
+
+    def get_cstr_at(self, address: int, limit: int = 0, vm=False, section_name=None):
+        """
+        Load a C style string from a location, stopping once a null byte is encountered.
+
+        :param address: Address to load string from
+        :param limit: Limit of the length of bytes, 0 = unlimited
+        :param vm: Is `address` a VM address?
+        :param section_name: if `vm==True`, the section name (vastly improves VM lookup time)
+        :return: The loaded C string
+        """
+        if vm:
+            address = self.vm.translate(address)
+        return self.slice.get_cstr_at(address, limit)
+
+    def decode_uleb128(self, readHead: int):
+        """
+        Decode a uleb128 integer from a location
+
+        :param readHead: Start location
+        :return: (end location, value)
+        """
+        return self.slice.decode_uleb128(readHead)
+

--- a/src/ktool/image.py
+++ b/src/ktool/image.py
@@ -83,7 +83,7 @@ class VM:
 
     def map_pages(self, physical_addr, virtual_addr, size):
         if physical_addr % self.page_size != 0 or virtual_addr % self.page_size != 0 or size % self.page_size != 0:
-            raise MachOAlignmentError
+            raise MachOAlignmentError(f'Tried to map {hex(virtual_addr)}+{hex(size)} to {hex(physical_addr)}')
         for i in range(size // self.page_size):
             self.page_table[virtual_addr + (i * self.page_size) >> self.page_size_bits] = physical_addr + (
                         i * self.page_size)

--- a/src/ktool/kcache.py
+++ b/src/ktool/kcache.py
@@ -16,7 +16,7 @@ from io import BytesIO
 import ktool
 from kmacho.structs import *
 from ktool import MachOFile, Image, log
-from ktool.dyld import ImageHeader, Dyld
+from ktool.loader import MachOImageHeader, MachOImageLoader
 import ktool.kplistlib as plistlib
 from ktool.exceptions import UnsupportedFiletypeException
 from ktool.macho import SlicedBackingFile
@@ -86,15 +86,15 @@ class MergedKext(Kext):
 
         # cool. we have a basic set of stuff in place, lets bootstrap up an Image from it.
 
-        self.mach_header = ImageHeader.from_image(self.backing_slice, file_base_addr)
+        self.mach_header = MachOImageHeader.from_image(self.backing_slice, file_base_addr)
         self.image = Image(self.backing_slice)
         self.image.macho_header = self.mach_header
         self.image.vm_realign(yell_about_misalignment=False)
 
         # noinspection PyProtectedMember
-        Dyld._parse_load_commands(self.image)
+        MachOImageLoader._parse_load_commands(self.image)
         # noinspection PyProtectedMember
-        Dyld._process_image(self.image)
+        MachOImageLoader._process_image(self.image)
 
         for segment in image.segments.values():
             segment.vm_address = segment.vm_address | 0xffff000000000000

--- a/src/ktool/ktool.py
+++ b/src/ktool/ktool.py
@@ -18,7 +18,7 @@
 from typing import Dict, Union, BinaryIO, List
 from io import BytesIO
 
-from ktool.dyld import Dyld, Image
+from ktool.loader import MachOImageLoader, Image
 from ktool.generator import TBDGenerator, FatMachOGenerator
 try:
     from ktool.headers import HeaderGenerator, Header
@@ -97,7 +97,7 @@ def load_image(fp: Union[BinaryIO, MachOFile, Slice, BytesIO, SlicedBackingFile]
         macho_file = load_macho_file(fp, use_mmaped_io=use_mmaped_io)
         macho_slice: Slice = macho_file.slices[slice_index]
 
-    return Dyld.load(macho_slice, load_symtab=load_symtab, load_imports=load_imports, load_exports=load_exports)
+    return MachOImageLoader.load(macho_slice, load_symtab=load_symtab, load_imports=load_imports, load_exports=load_exports)
 
 
 def macho_verify(fp: Union[BinaryIO, MachOFile, Slice, Image]) -> None:

--- a/src/ktool/ktool_script.py
+++ b/src/ktool/ktool_script.py
@@ -743,15 +743,13 @@ Modify the install name of a image
                     if cmd.cmd == 0xD:
                         id_dylib_index = i
                         break
-
-                dylib_item = Struct.create_with_values(dylib, [0x18, 2, 0, 0])
+                dylib_item = Struct.create_with_values(dylib, [0x18, 0x1, 0x000000, 0x000000])
                 new_header = image.macho_header.remove_load_command(id_dylib_index)
                 image.slice.patch(0, new_header.raw)
                 image = ktool.load_image(image.slice)
                 new_cmd = Struct.create_with_values(dylib_command, [LOAD_COMMAND.ID_DYLIB, 0, dylib_item.raw])
-                new_header = new_header.insert_load_cmd(new_cmd, id_dylib_index, new_iname)
+                new_header = image.macho_header.insert_load_cmd(new_cmd, id_dylib_index, new_iname)
                 image.slice.patch(0, new_header.raw)
-
                 patched_libraries.append(image)
 
         with open(args.out, 'wb') as fd:

--- a/src/ktool/ktool_script.py
+++ b/src/ktool/ktool_script.py
@@ -745,9 +745,9 @@ Modify the install name of a image
                         break
 
                 dylib_item = Struct.create_with_values(dylib, [0x18, 2, 0, 0])
-                image.macho_header.remove_load_command(id_dylib_index)
+                new_header = image.macho_header.remove_load_command(id_dylib_index)
                 new_cmd = Struct.create_with_values(dylib_command, [LOAD_COMMAND.ID_DYLIB, 0, dylib_item.raw])
-                new_header = image.macho_header.insert_load_cmd(new_cmd, id_dylib_index, new_iname)
+                new_header = new_header.insert_load_cmd(new_cmd, id_dylib_index, new_iname)
                 image.slice.patch(0, new_header.raw)
 
                 patched_libraries.append(image)

--- a/src/ktool/ktool_script.py
+++ b/src/ktool/ktool_script.py
@@ -698,8 +698,8 @@ commands currently supported:
 
             dylib_item = Struct.create_with_values(dylib, [0x18, 0x2, 0x010000, 0x010000])
             dylib_cmd = Struct.create_with_values(dylib_command, [lc.value, 0, dylib_item.raw])
-            image.macho_header.insert_load_cmd(dylib_cmd, last_dylib_command_index, suffix=args.payload)
-            image.slice.patch(0, image.macho_header.raw)
+            new_header = image.macho_header.insert_load_cmd(dylib_cmd, last_dylib_command_index, suffix=args.payload)
+            image.slice.patch(0, new_header.raw)
             log.info("Reloading MachO Slice to verify integrity")
             image = process_patches(image)
             patched_libraries.append(image)
@@ -747,8 +747,8 @@ Modify the install name of a image
                 dylib_item = Struct.create_with_values(dylib, [0x18, 2, 0, 0])
                 image.macho_header.remove_load_command(id_dylib_index)
                 new_cmd = Struct.create_with_values(dylib_command, [LOAD_COMMAND.ID_DYLIB, 0, dylib_item.raw])
-                image.macho_header.insert_load_cmd(new_cmd, id_dylib_index, new_iname)
-                image.slice.patch(0, image.macho_header.raw)
+                new_header = image.macho_header.insert_load_cmd(new_cmd, id_dylib_index, new_iname)
+                image.slice.patch(0, new_header.raw)
 
                 patched_libraries.append(image)
 

--- a/src/ktool/ktool_script.py
+++ b/src/ktool/ktool_script.py
@@ -746,6 +746,8 @@ Modify the install name of a image
 
                 dylib_item = Struct.create_with_values(dylib, [0x18, 2, 0, 0])
                 new_header = image.macho_header.remove_load_command(id_dylib_index)
+                image.slice.patch(0, new_header.raw)
+                image = ktool.load_image(image.slice)
                 new_cmd = Struct.create_with_values(dylib_command, [LOAD_COMMAND.ID_DYLIB, 0, dylib_item.raw])
                 new_header = new_header.insert_load_cmd(new_cmd, id_dylib_index, new_iname)
                 image.slice.patch(0, new_header.raw)

--- a/src/ktool/ktool_script.py
+++ b/src/ktool/ktool_script.py
@@ -472,6 +472,7 @@ def _open(args):
     """
 ktool open [filename]
     """
+    # noinspection PyUnreachableCode
     try:
         log.LOG_LEVEL = LogLevel.DEBUG
         screen = KToolScreen(args.hard_fail)
@@ -898,7 +899,7 @@ Print the list of function starts
                 print('(Weak) ' + extlib.install_name if extlib.weak else '' + extlib.install_name)
         elif args.get_fstarts:
             for addr in image.function_starts:
-                print(f'Addr: {hex(addr)} -> {image.symbols[addr].fullname if addr in image.symbols else ""}')
+                print(f'{hex(addr)} -> {image.symbols[addr].fullname if addr in image.symbols else ""}')
 
 
 def _file(args):
@@ -1067,7 +1068,8 @@ Dump info for a specific kext
                     break
 
         if isinstance(kext, Kext):
-            bundle_text = f"Bundle ID: {kext.id}\nExecutable Name: {kext.executable_name}\n{kext.info_string}\nVersion: {kext.version_str}\nStart Address: {hex(kext.start_addr | 0xffff000000000000)}"
+            bundle_text = f"Bundle ID: {kext.id}\nExecutable Name: {kext.executable_name}\n{kext.info_string}\n" \
+                          f"Version: {kext.version_str}\nStart Address: {hex(kext.start_addr | 0xffff000000000000)}"
             print(bundle_text)
         else:
             print('Kext Not Found')

--- a/src/ktool/macho.py
+++ b/src/ktool/macho.py
@@ -547,7 +547,7 @@ class MachOImageHeader(Constructable):
                 sect_data = command.raw[command.__class__.SIZE:]
                 struct_class = section_64 if isinstance(command, segment_command_64) else section
                 for i in range(command.nsects):
-                    sects.append(Struct.create_with_bytes(struct_class, sect_data[i*struct_class.SIZE:(i+1)*struct_class.SIZE], "little"))
+                    sects.append(Section(None, Struct.create_with_bytes(struct_class, sect_data[i*struct_class.SIZE:(i+1)*struct_class.SIZE], "little")))
                 seg = SegmentLoadCommand.from_values(isinstance(command, segment_command_64), command.segname, command.vmaddr, command.fileoff, command.vmsize, command.maxprot, command.initprot, command.flags, sects)
                 load_command_items.append(seg)
             elif isinstance(command, dylib_command):
@@ -607,9 +607,7 @@ class MachOImageHeader(Constructable):
                 sect_data = command.raw[command.__class__.SIZE:]
                 struct_class = section_64 if isinstance(command, segment_command_64) else section
                 for i in range(command.nsects):
-                    sects.append(Struct.create_with_bytes(struct_class,
-                                                          sect_data[i * struct_class.SIZE:(i + 1) * struct_class.SIZE],
-                                                          "little"))
+                    sects.append(Section(None, Struct.create_with_bytes(struct_class, sect_data[i*struct_class.SIZE:(i+1)*struct_class.SIZE], "little")))
                 seg = SegmentLoadCommand.from_values(isinstance(command, segment_command_64), command.segname,
                                                      command.vmaddr, command.fileoff, command.vmsize, command.maxprot,
                                                      command.initprot, command.flags, sects)

--- a/src/ktool/macho.py
+++ b/src/ktool/macho.py
@@ -612,6 +612,7 @@ class MachOImageHeader(Constructable):
 
         for command in self.load_commands:
             if current_lc_index == index:
+                current_lc_index += 1
                 continue
 
             if isinstance(command, segment_command) or isinstance(command, segment_command_64):

--- a/src/ktool/macho.py
+++ b/src/ktool/macho.py
@@ -554,7 +554,8 @@ class MachOImageHeader(Constructable):
                 suffix = ""
                 i = 0
                 while self.raw[command.off + command.__class__.SIZE + i] != "\x00":
-                    suffix += self.raw[command.off + command.__class__.SIZE + i].decode('utf-8')
+                    suffix += self.raw[command.off + command.__class__.SIZE + i].to_bytes(1, "little").decode('utf-8')
+                    i += 1
                 encoded = suffix.encode('utf-8') + b'\x00'
                 while (len(encoded) + command.__class__.SIZE) % 8 != 0:
                     encoded += b'\x00'
@@ -616,7 +617,8 @@ class MachOImageHeader(Constructable):
                 suffix = ""
                 i = 0
                 while self.raw[command.off + command.__class__.SIZE + i] != "\x00":
-                    suffix += self.raw[command.off + command.__class__.SIZE + i].decode('utf-8')
+                    suffix += self.raw[command.off + command.__class__.SIZE + i].to_bytes(1, "little").decode('utf-8')
+                    i += 1
                 encoded = suffix.encode('utf-8') + b'\x00'
                 while (len(encoded) + command.__class__.SIZE) % 8 != 0:
                     encoded += b'\x00'

--- a/src/ktool/macho.py
+++ b/src/ktool/macho.py
@@ -198,6 +198,7 @@ class Segment:
         self.vm_address = cmd.vmaddr
         self.file_address = cmd.fileoff
         self.size = cmd.vmsize
+        self.file_size = cmd.filesize
         self.name = cmd.segname
 
         self.sections: Dict[str, Section] = self._process_sections()
@@ -557,7 +558,9 @@ class MachOImageHeader(Constructable):
                 struct_class = section_64 if isinstance(command, segment_command_64) else section
                 for i in range(command.nsects):
                     sects.append(Section(None, Struct.create_with_bytes(struct_class, sect_data[i*struct_class.SIZE:(i+1)*struct_class.SIZE], "little")))
-                seg = SegmentLoadCommand.from_values(isinstance(command, segment_command_64), command.segname, command.vmaddr, command.fileoff, command.vmsize, command.maxprot, command.initprot, command.flags, sects)
+                seg = SegmentLoadCommand.from_values(isinstance(command, segment_command_64), command.segname,
+                                                     command.vmaddr, command.vmsize, command.fileoff, command.filesize,
+                                                     command.maxprot, command.initprot, command.flags, sects)
                 load_command_items.append(seg)
             elif isinstance(command, dylib_command):
                 _suffix = ""
@@ -622,8 +625,8 @@ class MachOImageHeader(Constructable):
                 for i in range(command.nsects):
                     sects.append(Section(None, Struct.create_with_bytes(struct_class, sect_data[i*struct_class.SIZE:(i+1)*struct_class.SIZE], "little")))
                 seg = SegmentLoadCommand.from_values(isinstance(command, segment_command_64), command.segname,
-                                                     command.vmaddr, command.fileoff, command.vmsize, command.maxprot,
-                                                     command.initprot, command.flags, sects)
+                                                     command.vmaddr, command.vmsize, command.fileoff, command.filesize,
+                                                     command.maxprot, command.initprot, command.flags, sects)
                 load_command_items.append(seg)
             elif isinstance(command, dylib_command):
                 suffix = ""

--- a/src/ktool/macho.py
+++ b/src/ktool/macho.py
@@ -553,8 +553,8 @@ class MachOImageHeader(Constructable):
             elif isinstance(command, dylib_command):
                 suffix = ""
                 i = 0
-                while self.raw[command.off + command.__class__.SIZE + i] != "\x00":
-                    suffix += self.raw[command.off + command.__class__.SIZE + i].to_bytes(1, "little").decode('utf-8')
+                while self.raw[command.off + command.__class__.SIZE + i] != 0:
+                    suffix += chr(self.raw[command.off + command.__class__.SIZE + i])
                     i += 1
                 encoded = suffix.encode('utf-8') + b'\x00'
                 while (len(encoded) + command.__class__.SIZE) % 8 != 0:
@@ -616,8 +616,8 @@ class MachOImageHeader(Constructable):
             elif isinstance(command, dylib_command):
                 suffix = ""
                 i = 0
-                while self.raw[command.off + command.__class__.SIZE + i] != "\x00":
-                    suffix += self.raw[command.off + command.__class__.SIZE + i].to_bytes(1, "little").decode('utf-8')
+                while self.raw[command.off + command.__class__.SIZE + i] != 0:
+                    suffix += chr(self.raw[command.off + command.__class__.SIZE + i])
                     i += 1
                 encoded = suffix.encode('utf-8') + b'\x00'
                 while (len(encoded) + command.__class__.SIZE) % 8 != 0:

--- a/src/ktool/macho.py
+++ b/src/ktool/macho.py
@@ -612,7 +612,7 @@ class MachOImageHeader(Constructable):
 
             if isinstance(command, segment_command) or isinstance(command, segment_command_64):
                 sects = []
-                sect_data = command.raw[command.__class__.SIZE:]
+                sect_data = self.raw[command.off + command.__class__.SIZE:]
                 struct_class = section_64 if isinstance(command, segment_command_64) else section
                 for i in range(command.nsects):
                     sects.append(Section(None, Struct.create_with_bytes(struct_class, sect_data[i*struct_class.SIZE:(i+1)*struct_class.SIZE], "little")))

--- a/src/ktool/objc.py
+++ b/src/ktool/objc.py
@@ -16,7 +16,7 @@ from enum import Enum
 from typing import List, Dict, Optional
 
 from kmacho.base import Constructable
-from ktool.dyld import Image
+from ktool.loader import Image
 from ktool.exceptions import VMAddressingError
 from ktool.structs import *
 from ktool.util import log, ignore, usi32_to_si32, opts, Queue, QueueItem

--- a/src/ktool/swift.py
+++ b/src/ktool/swift.py
@@ -18,7 +18,7 @@ from kswift.structs import *
 from kswift.demangle import demangle
 from ktool import ObjCImage
 
-from ktool.dyld import Image
+from ktool.loader import Image
 from ktool.macho import Section
 from ktool.objc import Class
 from ktool.util import usi32_to_si32

--- a/src/ktool/window.py
+++ b/src/ktool/window.py
@@ -42,7 +42,7 @@ from pygments.lexers.objective import ObjectiveCLexer
 from kmacho import LOAD_COMMAND
 
 from ktool.macho import MachOFile
-from ktool.dyld import Dyld
+from ktool.loader import MachOImageLoader
 from ktool.objc import ObjCImage
 from ktool.headers import HeaderGenerator
 from ktool.swift import load_swift_types, SwiftClass
@@ -1607,7 +1607,7 @@ class KToolMachOLoader:
 
     @staticmethod
     def slice_item(macho_slice, callback):
-        loaded_image = Dyld.load(macho_slice)
+        loaded_image = MachOImageLoader.load(macho_slice)
         if hasattr(macho_slice, 'type'):
             slice_nick = f'{macho_slice.type.name}:{macho_slice.subtype.name}' + " Slice"
         else:
@@ -1963,7 +1963,7 @@ class KToolKernelCacheLoader(KToolMachOLoader):
 
     @staticmethod
     def slice_item(macho_slice, callback):
-        loaded_image = Dyld.load(macho_slice)
+        loaded_image = MachOImageLoader.load(macho_slice)
         slice_nick = f'Kernel Cache'
         callback(f'Kernel Cache\nLoading MachO Image')
         slice_item = SidebarMenuItem(f'Kernel Cache', None, None)

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -18,13 +18,14 @@ import unittest
 from io import BytesIO
 import random
 
-from ktool.dyld import ImageHeader
+from ktool.loader import MachOImageHeader
 
 import ktool
 from ktool.headers import *
 from ktool.macho import *
 from ktool.objc import *
 from ktool.util import *
+from ktool.image import *
 
 # We need to be in the right directory so we can find the bins
 scriptdir = os.path.dirname(os.path.realpath(__file__))
@@ -401,7 +402,7 @@ class ImageHeaderTestCase(unittest.TestCase):
             else:
                 load_command_items.append(command)
 
-        new_image_header = ImageHeader.from_values(image.macho_header.is64, cpu_type, cpu_subtype, filetype, flags, load_command_items)
+        new_image_header = MachOImageHeader.from_values(image.macho_header.is64, cpu_type, cpu_subtype, filetype, flags, load_command_items)
 
         self.thin.write(0, new_image_header.raw_bytes())
 
@@ -445,7 +446,7 @@ class ImageHeaderTestCase(unittest.TestCase):
             else:
                 load_command_items.append(command)
 
-        new_image_header = ImageHeader.from_values(image.macho_header.is64, cpu_type, cpu_subtype, filetype, flags, load_command_items)
+        new_image_header = MachOImageHeader.from_values(image.macho_header.is64, cpu_type, cpu_subtype, filetype, flags, load_command_items)
 
         self.thin.write(0, new_image_header.raw_bytes())
 
@@ -485,9 +486,6 @@ class DyldTestCase(unittest.TestCase):
                          "/System/Library/Frameworks/Foundation.framework/Versions/C/Foundation")
         self.assertEqual(image.linked_images[1].install_name, "/usr/lib/libSystem.B.dylib")
         self.assertEqual(image.linked_images[2].install_name, "/usr/lib/libobjc.A.dylib")
-
-
-
 
 
 if __name__ == '__main__':

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -13,6 +13,7 @@
 #
 import math
 import os
+import pprint
 import sys
 import unittest
 from io import BytesIO
@@ -40,18 +41,21 @@ def diff_byte_array_set_assertion(old: bytearray, new: bytearray):
     if old != new:
         diff = "        Old       New\n"
         for index in range(0, len(old), 4):
-            old_bytes = old[index:index+4]
-            new_bytes = new[index:index+4]
+            old_bytes = old[index:index + 4]
+            new_bytes = new[index:index + 4]
             set_is_diff = False
             for sub_index, byte in enumerate(old_bytes):
-                if byte != new_bytes[sub_index]:
+                try:
+                    if byte != new_bytes[sub_index]:
+                        set_is_diff = True
+                except IndexError:
                     set_is_diff = True
             if set_is_diff:
                 diff += hex(index).ljust(8)
                 diff += old_bytes.hex() + '  '
                 diff += new_bytes.hex() + '  '
                 diff += "\n"
-        print(diff, file=sys.stderr)
+        print(diff)
         raise AssertionError
 
 
@@ -74,11 +78,11 @@ def disable_error_capture():
     log.LOG_ERR = print_err
 
 
-#  ---------
-#  To make testing easier, we use "scratch files"; base mach-os (testbin1, testbin1.fat) that we modify and reset
-#      in reliable ways. The underlying file should not matter whatsoever, we just need *any* mach-o.
-#  Tests should be written in a way entirely independent of the underlying file, manually writing the values we're going to test.
-#  ---------
+# ---------
+# To make testing easier, we use "scratch files"; base mach-os (testbin1, testbin1.fat) that we modify and
+# reset in reliable ways. The underlying file should not matter whatsoever, we just need *any* mach-o. Tests should
+# be written in a way entirely independent of the underlying file, manually writing the values we're going to test.
+# ---------
 
 class ScratchFile:
     def __init__(self, fp):
@@ -116,6 +120,15 @@ class ScratchFile:
         self.scratch.write(self.backup.read())
         self.backup.seek(0)
         self.scratch.seek(0)
+
+
+class StructTestCase(unittest.TestCase):
+    def test_equality_check(self):
+        s1 = Struct.create_with_values(linkedit_data_command, [0x34 | LC_REQ_DYLD, 0x10, 0xc000, 0xd0], "little")
+        s2 = Struct.create_with_values(linkedit_data_command, [0x34 | LC_REQ_DYLD, 0x10, 0xc000, 0xd0], "little")
+        s3 = Struct.create_with_values(linkedit_data_command, [0x34 | LC_REQ_DYLD, 0x10, 0xc000, 0xe0], "little")
+        assert s1 == s2
+        assert s1 != s3
 
 
 class MachOLoaderTestCase(unittest.TestCase):
@@ -196,12 +209,12 @@ class SegmentLCTestCase(unittest.TestCase):
         text_sections = []
         for s in text.sections.values():
             text_sections.append(s)
-        lc = SegmentLoadCommand.from_values(image_header.is64, '__TEXT', text.vm_address, text.file_address, text.size,
+        lc = SegmentLoadCommand.from_values(image_header.is64, '__TEXT', text.vm_address, text.size, text.file_address,
+                                            text.file_size,
                                             cmd.maxprot, cmd.initprot, cmd.flags, text_sections)
         new_dat = lc.raw_bytes()
 
         diff_byte_array_set_assertion(bytearray(old_dat), bytearray(new_dat))
-
 
 
 class VMTestCase(unittest.TestCase):
@@ -266,7 +279,8 @@ class SliceTestCase(unittest.TestCase):
         macho_slice.patch(0x0, b'\xDE\xAD\xBE\xEF')
         self.fat.write(macho_slice.offset, 0xDEADBEEF)
 
-        self.assertEqual(macho_slice.full_bytes_for_slice(), bytes(bytearray(self.fat.get().read())[macho_slice.offset:macho_slice.offset+macho_slice.size]))
+        self.assertEqual(macho_slice.full_bytes_for_slice(), bytes(
+            bytearray(self.fat.get().read())[macho_slice.offset:macho_slice.offset + macho_slice.size]))
 
     def test_find(self):
         self.thin.reset()
@@ -394,6 +408,7 @@ class ImageHeaderTestCase(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.thin = ScratchFile(open(scriptdir + '/bins/testbin1', 'rb'))
+        self.thin_lib = ScratchFile(open(scriptdir + '/bins/testlib1.dylib', 'rb'))
 
     def test_constructable(self):
         self.thin.reset()
@@ -430,7 +445,8 @@ class ImageHeaderTestCase(unittest.TestCase):
             else:
                 load_command_items.append(command)
 
-        new_image_header = MachOImageHeader.from_values(image.macho_header.is64, cpu_type, cpu_subtype, filetype, flags, load_command_items)
+        new_image_header = MachOImageHeader.from_values(image.macho_header.is64, cpu_type, cpu_subtype, filetype, flags,
+                                                        load_command_items)
 
         self.thin.write(0, new_image_header.raw_bytes())
 
@@ -474,7 +490,8 @@ class ImageHeaderTestCase(unittest.TestCase):
             else:
                 load_command_items.append(command)
 
-        new_image_header = MachOImageHeader.from_values(image.macho_header.is64, cpu_type, cpu_subtype, filetype, flags, load_command_items)
+        new_image_header = MachOImageHeader.from_values(image.macho_header.is64, cpu_type, cpu_subtype, filetype, flags,
+                                                        load_command_items)
 
         self.thin.write(0, new_image_header.raw_bytes())
 
@@ -495,8 +512,15 @@ class ImageHeaderTestCase(unittest.TestCase):
         dylib_item = Struct.create_with_values(dylib, [0x18, 0x2, 0x010000, 0x010000])
         dylib_cmd = Struct.create_with_values(dylib_command, [LOAD_COMMAND.LOAD_DYLIB.value, 0, dylib_item.raw])
         new_header = image.macho_header.insert_load_cmd(dylib_cmd, -1, suffix="/unit/test")
+
         assert len(image_header.load_commands) + 1 == len(new_header.load_commands)
         assert b'/unit/test' in new_header.raw
+        assert image_header.raw != new_header.raw
+
+        self.thin.write(0, new_header.raw)
+
+        new_image = ktool.load_image(self.thin.get())
+        assert new_image.linked_images[-1].install_name == '/unit/test'
 
     def test_remove_cmd(self):
 
@@ -504,10 +528,41 @@ class ImageHeaderTestCase(unittest.TestCase):
 
         image = ktool.load_image(self.thin.get())
         image_header = image.macho_header
-        lc = image.macho_header.load_commands[5]
 
         new_header = image.macho_header.remove_load_command(5)
         assert (len(image_header.load_commands) - 1 == len(new_header.load_commands))
+        self.thin.write(0, new_header.raw_bytes())
+
+        ktool.load_image(self.thin.get())
+
+    def test_replace_load_command(self):
+        self.thin_lib.reset()
+
+        image = ktool.load_image(self.thin_lib.get())
+        image_header = image.macho_header
+        old_commands = [*image_header.load_commands]
+
+        new_header = image.macho_header.remove_load_command(4)
+        assert (len(image_header.load_commands) - 1 == len(new_header.load_commands))
+        self.thin_lib.write(0, new_header.raw_bytes())
+
+        image = ktool.load_image(self.thin_lib.get())
+        image_header = image.macho_header
+
+        dylib_item = Struct.create_with_values(dylib, [0x18, 0x1, 0x000000, 0x000000])
+        dylib_cmd = Struct.create_with_values(dylib_command, [LOAD_COMMAND.ID_DYLIB.value, 0, dylib_item.raw])
+        new_header = image.macho_header.insert_load_cmd(dylib_cmd, 4, suffix="/unit/test/iname")
+
+        self.thin_lib.write(0, new_header.raw)
+
+        new_image = ktool.load_image(self.thin_lib.get())
+        assert new_image.install_name == '/unit/test/iname'
+
+        for i, cmd in enumerate(new_header.load_commands):
+            if not cmd == old_commands[i]:
+                log.error(f'{str(cmd)} != {str(old_commands[i])}')
+                raise AssertionError
+
 
 class DyldTestCase(unittest.TestCase):
     """

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -494,8 +494,9 @@ class ImageHeaderTestCase(unittest.TestCase):
 
         dylib_item = Struct.create_with_values(dylib, [0x18, 0x2, 0x010000, 0x010000])
         dylib_cmd = Struct.create_with_values(dylib_command, [LOAD_COMMAND.LOAD_DYLIB.value, 0, dylib_item.raw])
-        image.macho_header.insert_load_cmd(dylib_cmd, -1, suffix="/unit/test")
-
+        new_header = image.macho_header.insert_load_cmd(dylib_cmd, -1, suffix="/unit/test")
+        assert len(image_header.load_commands) + 1 == len(new_header.load_commands)
+        assert b'/unit/test' in new_header.raw
 
 
 class DyldTestCase(unittest.TestCase):

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -498,6 +498,16 @@ class ImageHeaderTestCase(unittest.TestCase):
         assert len(image_header.load_commands) + 1 == len(new_header.load_commands)
         assert b'/unit/test' in new_header.raw
 
+    def test_remove_cmd(self):
+
+        self.thin.reset()
+
+        image = ktool.load_image(self.thin.get())
+        image_header = image.macho_header
+        lc = image.macho_header.load_commands[5]
+
+        new_header = image.macho_header.remove_load_command(5)
+        assert (len(image_header.load_commands) - 1 == len(new_header.load_commands))
 
 class DyldTestCase(unittest.TestCase):
     """


### PR DESCRIPTION
Class Renames:
Dyld -> MachOImageLoader
ImageHeader -> MachOImageHeader

LD64 class was removed
`insert_load_cmd(load_command, index=-1, suffix=None)` and `remove_load_command(index)` added to MachOImageHeader which supports adding and removing *all* types of load commands now.

`ktool.dyld` module renamed to `ktool.loader`, now contains only code relavent specifically to loading the `Image` class from a standard MachO
`Image` class and a few others moved to new `image.py`, in which contained code is a non-platform-specific abstraction not tied to MachO.

Fixes:
* Rewritten load command injection should fix issues with round-tripping and producing bad patches. A ton of unit testing for this area was added to try and maintain this.
* Fix for some issues on certain weird linux environments

Improvements:
* ktool no longer tries to guess the property getter/setter; it decodes it from the actual standard attr_string or generates it from the property name if none is specified. This avoids potential false positives and also clarifies when non standard ones are used. We also decode whether a property is @ dynamic but do not encode that in the header yet.
* json output for properties now embeds attr_string, getter, and setter.